### PR TITLE
fix getting instance value

### DIFF
--- a/lib-ts_netns.c
+++ b/lib-ts_netns.c
@@ -32,7 +32,7 @@ libts_netns_get_sfc_ta(char **ta)
     te_errno rc;
     char     *if_name;
     char     *agent;
-    int       status;
+    int32_t  status;
 
     agent = getenv("TE_IUT_TA_NAME");
     if (agent == NULL)
@@ -48,9 +48,8 @@ libts_netns_get_sfc_ta(char **ta)
         return TE_RC(TE_TAPI, te_rc_os2te(errno));
     }
 
-    rc = cfg_get_instance_fmt(CVT_INTEGER, &status,
-                              "/agent:%s/interface:%s/status:",
-                              agent, if_name);
+    rc = cfg_get_int32(&status, "/agent:%s/interface:%s/status:",
+                       agent, if_name);
     if (rc == TE_RC(TE_CS, TE_ENOENT))
     {
         agent = getenv("TE_IUT_TA_NAME_NS");


### PR DESCRIPTION
Pointer to cfg_val_type should be passed as an argument to cfg_get_instance() instead of a constant. Moreover here we use new function cfg_get_int32().

OL-Redmine-Id: 11890
Signed-off-by: Nikolai Kosovskii <nikolai.kosovskii@oktetlabs.ru>
Reviewed-by: Damir Mansurov <damir.mansurov@oktetlabs.ru>

---

Testing done:

Checked with sapi-ts running

`./run.sh -q --cfg=thorin1 --tester-run=sockapi-ts/usecases/send_recv`